### PR TITLE
[Feature] 버스 조회 API 수정

### DIFF
--- a/app/api/bus.py
+++ b/app/api/bus.py
@@ -3,7 +3,7 @@ import httpx
 busColor = {
     # RED
     "광역" : "#F72F08",
-    "직행" : "#F72F08",
+    "직행좌석" : "#F72F08",
 
     # GREEN
     "지선" : "#5BB025",

--- a/app/api/bus.py
+++ b/app/api/bus.py
@@ -12,8 +12,10 @@ async def get_busList(url: str):
                     data.append({
                         "bus_id": temp["routeid"],
                         "name": temp["routeno"],
+                        "type": temp["routetp"][0:-2],
                         "color": "#aaffaa",
-                        "near_station": ["???", "??", "?", "Next"]
+                        "station_left": temp["arrprevstationcnt"],
+                        "time_left": temp["arrtime"]
                     })
                 return {
                     "status": 200,

--- a/app/api/bus.py
+++ b/app/api/bus.py
@@ -1,5 +1,44 @@
 import httpx
 
+busColor = {
+    # RED
+    "광역" : "#F72F08",
+    "직행" : "#F72F08",
+
+    # GREEN
+    "지선" : "#5BB025",
+    "맞춤" : "#5BB025",
+    "마을" : "#5BB025",
+
+    # BLUE
+    "간선" : "#3D5BAB",
+    "심야" : "#3D5BAB",
+    "좌석" : "#3D5BAB",
+    "일반" : "#3D5BAB",
+
+    # YELLOW
+    "순환" : "#F99D1C",
+    "투어" : "#F99D1C",
+
+    # BROWN
+    "공항" : "#8B4513",
+
+    # PURPLE
+    "급행" : "#6E2DB9",
+
+    # Another
+    "BRT" : "#CB2B2B",
+    "두루타" : "#00A0C6",
+    "누비다" : "#FF69B4",
+    "임시" : "#FFBC00",
+    "행복" : "#FA5882",
+    "읍면" : "#5FBF15",
+    "마실" : "#FFBC00",
+    "출근" : "#82D438",
+    "군위" : "#002187",
+    "폐선" : "#AAAAAA"
+}
+
 # GET Method
 async def get_busList(url: str):
     async with httpx.AsyncClient() as client:
@@ -13,7 +52,7 @@ async def get_busList(url: str):
                         "bus_id": temp["routeid"],
                         "name": temp["routeno"],
                         "type": temp["routetp"][0:-2],
-                        "color": "#aaffaa",
+                        "color": busColor.get(temp["routetp"][0:-2]),
                         "station_left": temp["arrprevstationcnt"],
                         "time_left": temp["arrtime"]
                     })

--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 load_dotenv(os.path.join(BASE_DIR, ".env"))
 
 #models.Base.metadata.create_all(bind=engine)
-openApiEndpoint = "http://apis.data.go.kr/1613000/BusSttnInfoInqireService"
+openApiEndpoint = "http://apis.data.go.kr/1613000"
 
 
 app = FastAPI()
@@ -36,11 +36,11 @@ async def read_root():
 
 @app.get("/api/v1/station")
 async def read_station_by_location(lat: float, lon: float, skip: int = 0):
-    url = f"{openApiEndpoint}/getCrdntPrxmtSttnList?serviceKey={os.environ["data_go_kr_key"]}&_type=json&gpsLati={lat}&gpsLong={lon}"
+    url = f"{openApiEndpoint}/BusSttnInfoInqireService/getCrdntPrxmtSttnList?serviceKey={os.environ["data_go_kr_key"]}&_type=json&gpsLati={lat}&gpsLong={lon}"
     return await get_station(url, skip)
 
 @app.get("/api/v1/bus")
-async def read_buses_by_station(cityCode: int, stationId: str):
-    url = f"{openApiEndpoint}/getSttnThrghRouteList?serviceKey={os.environ["data_go_kr_key"]}&_type=json&cityCode={cityCode}&nodeid={stationId}"
+async def read_buses_by_station(stationId: str, cityCode: int):
+    url = f"{openApiEndpoint}/ArvlInfoInqireService/getSttnAcctoArvlPrearngeInfoList?serviceKey={os.environ["data_go_kr_key"]}&_type=json&cityCode={cityCode}&nodeId={stationId}"
     return await get_busList(url)
 

--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,9 @@ async def read_station_by_location(lat: float, lon: float, skip: int = 0):
 
 @app.get("/api/v1/bus")
 async def read_buses_by_station(stationId: str, cityCode: int):
+    url = f"{openApiEndpoint}/BusSttnInfoInqireService/getSttnThrghRouteList?serviceKey={os.environ["data_go_kr_key"]}&_type=json&cityCode={cityCode}&nodeid={stationId}"
+    data = await get_curSttnBusList(url)
+    print(data)
     url = f"{openApiEndpoint}/ArvlInfoInqireService/getSttnAcctoArvlPrearngeInfoList?serviceKey={os.environ["data_go_kr_key"]}&_type=json&cityCode={cityCode}&nodeId={stationId}"
-    return await get_busList(url)
+    return await get_arvlBusList(url, data)
 


### PR DESCRIPTION
### 머릿말
---
초기 버스 조회 API는 정류장 경유 버스 목록만 출력
여기서, 도착 예정인 버스 목록 출력으로 수정했으나, OpenAPI로 부터 몇몇 버스들의 도착 예정 정보가 없으면 아예 응답 받지 못하는 문제 발생.
때문에, 먼저 정류장 경유 버스 목록을 받아서 거기에, 도착 예정인 버스 목록을 받아서 해당하는 버스의 도착 예정 정보를 반영

### 수정된 기능
---
- 정류장 경유 버스 목록 조회 + 도착 예정 버스 목록 조회
- 응답 내용 수정
- 버스 유형에 따른 색상 반환

### 연결된 이슈
---
#13 